### PR TITLE
Fix incorrect version in package manifest

### DIFF
--- a/weatherflow/packageManifest.json
+++ b/weatherflow/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "WeatherFlow Lite",
   "author": "Justin Walker (augoisms)",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minimumHEVersion": "2.2.0",
   "dateReleased": "2020-08-23",
   "releaseNotes": "Added null handling and battery status.",


### PR DESCRIPTION
When 1.0.6 was released, the package manifest was updated to reflect the date and latest change, but the version was not updated.